### PR TITLE
Bump kops version to 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ENV KOPS_VERSION=1.8.0
+ENV KOPS_VERSION=1.8.1
 # https://kubernetes.io/docs/tasks/kubectl/install/
 # latest stable kubectl: curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
 ENV KUBECTL_VERSION=v1.8.7


### PR DESCRIPTION
Bumps kops to 1.8.1.

Not sure what the process is for pushing a new image to dockerhub, tagging, etc.