### PR TITLE
AIR-30696 github CODEOWNERS set to devops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AirHelp/devops


### PR DESCRIPTION
Requestor/Jira: Rafal Radecki/https://jira.airhelp.com/browse/AIR-30696
Risk (low/med/high): low
Description/Why: there is a need to add CODEOWNERS file for all devops repos which do not have it at the moment