### PR TITLE
Upgrade to kops 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.7
+FROM alpine:3.10
 
-ENV KOPS_VERSION=1.10.0
+ENV KOPS_VERSION=1.15.0
 # https://kubernetes.io/docs/tasks/kubectl/install/
 # latest stable kubectl: curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt
-ENV KUBECTL_VERSION=v1.11.2
+ENV KUBECTL_VERSION=v1.16.3
 
 RUN apk --no-cache add ca-certificates \
   && apk --no-cache add --virtual build-dependencies curl \


### PR DESCRIPTION
To allows migrate to 1.15+. 
Kops migrated to CRDs, so with old version it breaks.

1.10 fails with the error when trying to update cluster to 1.15 :
```
no kind "Cluster" is registered for version "kops.k8s.io/v1alpha2" in scheme "k8s.io/kops/pkg/kopscodecs/codecs.go:33"
```
